### PR TITLE
Add client-side content length validation for secrets

### DIFF
--- a/assets/js/hooks/createSecret.js
+++ b/assets/js/hooks/createSecret.js
@@ -1,7 +1,20 @@
 import Encryption from "../encryption";
 
+// Maximum content size constants
+// Server limit is 4096 bytes for encrypted content
+// Overhead: 37 bytes (burnkey UUID + newline) + 16 bytes (AES-GCM auth tag) = 53 bytes
+const MAX_CLEARTEXT_BYTES = 4043;
+
+// Calculate the UTF-8 byte length of a string
+function getByteLength(str) {
+  return new TextEncoder().encode(str).length;
+}
+
 const CreateSecret = {
   mounted() {
+    // Set up content length validation
+    this.setupContentValidation();
+
     this.el.addEventListener("submit", async (event) => {
       if (!this.shouldSubmit()) {
         // prevent the event from bubbling to the default LiveView handler
@@ -9,6 +22,11 @@ const CreateSecret = {
 
         // prevent the default browser behavior (submitting the form over HTTP)
         event.preventDefault();
+
+        // Check if content is too long
+        if (!this.isContentValid()) {
+          return;
+        }
 
         var form = this.el;
 
@@ -107,6 +125,51 @@ const CreateSecret = {
   },
   shouldSubmit() {
     return this.submit_flag;
+  },
+
+  setupContentValidation() {
+    var cleartextEl = document.getElementById("cleartext");
+    var warningEl = document.getElementById("content-length-warning");
+    var messageEl = document.getElementById("content-length-message");
+    var buttonEl = document.getElementById("encrypt-button");
+
+    if (!cleartextEl || !warningEl || !buttonEl) {
+      return;
+    }
+
+    var self = this;
+
+    var validateContent = function () {
+      var byteLength = getByteLength(cleartextEl.value);
+      var isOverLimit = byteLength > MAX_CLEARTEXT_BYTES;
+
+      if (isOverLimit) {
+        var overBy = byteLength - MAX_CLEARTEXT_BYTES;
+        messageEl.textContent =
+          "Your secret is " +
+          overBy +
+          " bytes over the maximum size of " +
+          MAX_CLEARTEXT_BYTES +
+          " bytes. Please shorten your content.";
+        warningEl.classList.remove("hidden");
+        buttonEl.disabled = true;
+        self.contentTooLong = true;
+      } else {
+        warningEl.classList.add("hidden");
+        buttonEl.disabled = false;
+        self.contentTooLong = false;
+      }
+    };
+
+    // Validate on input
+    cleartextEl.addEventListener("input", validateContent);
+
+    // Run initial validation in case there's pre-filled content
+    validateContent();
+  },
+
+  isContentValid() {
+    return !this.contentTooLong;
   },
 };
 export default CreateSecret;

--- a/assets/js/hooks/createSecret.js
+++ b/assets/js/hooks/createSecret.js
@@ -1,10 +1,5 @@
 import Encryption from "../encryption";
 
-// Maximum content size constants
-// Server limit is 4096 bytes for encrypted content
-// Overhead: 37 bytes (burnkey UUID + newline) + 16 bytes (AES-GCM auth tag) = 53 bytes
-const MAX_CLEARTEXT_BYTES = 4043;
-
 // Calculate the UTF-8 byte length of a string
 function getByteLength(str) {
   return new TextEncoder().encode(str).length;
@@ -12,6 +7,9 @@ function getByteLength(str) {
 
 const CreateSecret = {
   mounted() {
+    // Read max cleartext size from data attribute (configured server-side)
+    this.maxCleartextBytes = parseInt(this.el.dataset.maxCleartextSize, 10);
+
     // Set up content length validation
     this.setupContentValidation();
 
@@ -139,17 +137,19 @@ const CreateSecret = {
 
     var self = this;
 
+    var maxBytes = self.maxCleartextBytes;
+
     var validateContent = function () {
       var byteLength = getByteLength(cleartextEl.value);
-      var isOverLimit = byteLength > MAX_CLEARTEXT_BYTES;
+      var isOverLimit = byteLength > maxBytes;
 
       if (isOverLimit) {
-        var overBy = byteLength - MAX_CLEARTEXT_BYTES;
+        var overBy = byteLength - maxBytes;
         messageEl.textContent =
           "Your secret is " +
           overBy +
           " bytes over the maximum size of " +
-          MAX_CLEARTEXT_BYTES +
+          maxBytes +
           " bytes. Please shorten your content.";
         warningEl.classList.remove("hidden");
         buttonEl.disabled = true;

--- a/assets/js/hooks/createSecret.js
+++ b/assets/js/hooks/createSecret.js
@@ -1,16 +1,14 @@
 import Encryption from "../encryption";
 
-// Calculate the UTF-8 byte length of a string
 function getByteLength(str) {
   return new TextEncoder().encode(str).length;
 }
 
 const CreateSecret = {
   mounted() {
-    // Read max cleartext size from data attribute (configured server-side)
+    // Max cleartext size is configured server-side in this data attribute
     this.maxCleartextBytes = parseInt(this.el.dataset.maxCleartextSize, 10);
 
-    // Set up content length validation
     this.setupContentValidation();
 
     this.el.addEventListener("submit", async (event) => {
@@ -21,7 +19,6 @@ const CreateSecret = {
         // prevent the default browser behavior (submitting the form over HTTP)
         event.preventDefault();
 
-        // Check if content is too long
         if (!this.isContentValid()) {
           return;
         }

--- a/lib/livesecret/secret.ex
+++ b/lib/livesecret/secret.ex
@@ -5,6 +5,11 @@ defmodule LiveSecret.Secret do
 
   @maxcontentsize 4096
   @ivsize 12
+  # Encryption overhead: 37 bytes (burnkey UUID + newline) + 16 bytes (AES-GCM auth tag)
+  @encryption_overhead 53
+
+  def max_content_size, do: @maxcontentsize
+  def max_cleartext_size, do: @maxcontentsize - @encryption_overhead
 
   @primary_key {:id, :string, autogenerate: false}
   schema "secrets" do

--- a/lib/livesecret_web/components/secret_form_component.ex
+++ b/lib/livesecret_web/components/secret_form_component.ex
@@ -15,6 +15,7 @@ defmodule LiveSecretWeb.SecretFormComponent do
       phx-submit="create"
       phx-hook="CreateSecret"
       autocomplete="off"
+      data-max-cleartext-size={@max_cleartext_size}
     >
       <div class="overflow-hidden rounded-lg border border-gray-300 shadow-sm focus-within:border-indigo-500 focus-within:ring-1 focus-within:ring-indigo-500">
         <div class="flex">
@@ -36,7 +37,7 @@ defmodule LiveSecretWeb.SecretFormComponent do
           />
           <div id="content-length-warning" class="hidden px-3 py-2 text-sm text-red-600 bg-red-50 border-t border-red-200">
             <span class="font-medium">Content too long:</span>
-            <span id="content-length-message">Your secret exceeds the maximum size of 4043 bytes.</span>
+            <span id="content-length-message">Your secret exceeds the maximum allowed size.</span>
           </div>
         </div>
         {hidden_input(f, :content, id: "ciphertext")}

--- a/lib/livesecret_web/components/secret_form_component.ex
+++ b/lib/livesecret_web/components/secret_form_component.ex
@@ -34,6 +34,10 @@ defmodule LiveSecretWeb.SecretFormComponent do
             class="h-24 sm:h-64 pt-3 block w-full resize-y border-0 py-0 placeholder-gray-500 focus:ring-0 font-mono"
             placeholder="Put your secret information here..."
           />
+          <div id="content-length-warning" class="hidden px-3 py-2 text-sm text-red-600 bg-red-50 border-t border-red-200">
+            <span class="font-medium">Content too long:</span>
+            <span id="content-length-message">Your secret exceeds the maximum size of 4043 bytes.</span>
+          </div>
         </div>
         {hidden_input(f, :content, id: "ciphertext")}
         {hidden_input(f, :iv, id: "iv")}
@@ -211,8 +215,9 @@ defmodule LiveSecretWeb.SecretFormComponent do
     ~H"""
     <div class="flex-shrink-0">
       <button
+        id="encrypt-button"
         type="submit"
-        class="inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+        class="inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         Encrypt
       </button>

--- a/lib/livesecret_web/components/secret_form_component.ex
+++ b/lib/livesecret_web/components/secret_form_component.ex
@@ -17,6 +17,10 @@ defmodule LiveSecretWeb.SecretFormComponent do
       autocomplete="off"
       data-max-cleartext-size={@max_cleartext_size}
     >
+      <div id="content-length-warning" class="hidden px-3 py-2 text-sm text-red-600 bg-red-50 border rounded-lg border-red-200">
+        <span class="font-medium">Content too long:</span>
+        <span id="content-length-message">Your secret exceeds the maximum allowed size.</span>
+      </div>
       <div class="overflow-hidden rounded-lg border border-gray-300 shadow-sm focus-within:border-indigo-500 focus-within:ring-1 focus-within:ring-indigo-500">
         <div class="flex">
           <input
@@ -35,10 +39,6 @@ defmodule LiveSecretWeb.SecretFormComponent do
             class="h-24 sm:h-64 pt-3 block w-full resize-y border-0 py-0 placeholder-gray-500 focus:ring-0 font-mono"
             placeholder="Put your secret information here..."
           />
-          <div id="content-length-warning" class="hidden px-3 py-2 text-sm text-red-600 bg-red-50 border-t border-red-200">
-            <span class="font-medium">Content too long:</span>
-            <span id="content-length-message">Your secret exceeds the maximum allowed size.</span>
-          </div>
         </div>
         {hidden_input(f, :content, id: "ciphertext")}
         {hidden_input(f, :iv, id: "iv")}

--- a/lib/livesecret_web/live/page_live.html.heex
+++ b/lib/livesecret_web/live/page_live.html.heex
@@ -36,8 +36,8 @@
             <SecretFormComponent.create
               changeset={@changeset}
               modes={Presecret.supported_modes()}
-              ,
               durations={Presecret.supported_durations()}
+              max_cleartext_size={Secret.max_cleartext_size()}
             />
             <PageComponents.section_header>
               <:title>Help</:title>


### PR DESCRIPTION
When users enter content that exceeds the maximum size limit (4043 bytes),
they now receive immediate visual feedback:
- Warning message displayed below the textarea
- Encrypt button is disabled with visual indication
- Form submission is prevented until content is shortened

This addresses issue #31 where the form would silently fail without
any feedback when content was too long.

https://claude.ai/code/session_01Mzga5xeu5STsVPJex2EEMe